### PR TITLE
US19379: Add support for forwarded header on Amazon ELB

### DIFF
--- a/src/main/java/org/springframework/hateoas/PagedResources.java
+++ b/src/main/java/org/springframework/hateoas/PagedResources.java
@@ -79,7 +79,13 @@ public class PagedResources<T> extends Resources<T> {
     public PagedResources(Collection<T> content, boolean includeCurie, PageMetadata metadata, Link... links) {
         this(content, metadata, Arrays.asList(links));
 
-        // Non IANA defined relation type is used to trigger curies during serialization
+		// A curies link relation is added during serialization when there are custom link relations in the resource
+		// being serialized.
+		//
+		// Paginated resources often have only IANA defined link relations (prev, next, etc) and thus don't get curies.
+		// However, we may want curies if the resources being paginated are embedded with custom relations.
+		//
+		// To enable this, we add a non IANA relation Link that does not get rendered during serialization.
         if (includeCurie && metadata.getTotalElements() > 0) {
             this.add(CURIE_REQUIRED_LINK);
         }

--- a/src/main/java/org/springframework/hateoas/hal/Jackson2HalModule.java
+++ b/src/main/java/org/springframework/hateoas/hal/Jackson2HalModule.java
@@ -139,6 +139,7 @@ public class Jackson2HalModule extends SimpleModule {
 
 			for (Link link : value) {
 
+				// CURIE_REQUIRED_LINK link is used to trigger curies on paginated resources. We don't serialize it.
                 if (link.equals(PagedResources.CURIE_REQUIRED_LINK)) {
                     curiedLinkPresent = true;
                     continue;

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -301,7 +301,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 	 * @see #170
 	 */
 	@Test
-	public void usesForwardedPortFromHeader() {
+	public void usesPortFromForwardedHostHeader() {
 
 		request.addHeader("X-Forwarded-Host", "foobarhost");
 		request.addHeader("X-Forwarded-Port", "9090");
@@ -309,7 +309,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
 
-		assertThat(link.getHref(), startsWith("http://foobarhost:9090/"));
+		assertThat(link.getHref(), startsWith("http://foobarhost/"));
 	}
 
 	/**


### PR DESCRIPTION
Changed order of proto lookup to: Forwarded, X-Forwarded-Ssl, X-Forwarded-Proto. The value of X-Forwarded-Port is applied regardless of Forwarded and X-Forwarded-Host headers. However, if a host is provided in Forwarded or X-Forwarded-Host, the port from host overwrites/resets the value from X-Forwarded-Port header.